### PR TITLE
Update Original_With_Reps

### DIFF
--- a/Original_With_Reps
+++ b/Original_With_Reps
@@ -73,15 +73,4 @@ else:
     print ""
     print "And Hillary Wins!"
     
-print "Next, the Republican side:"
 
-for reps in candidates_rep:
-    if rep_turnout > 0.1379:
-        def trump_win(candidates_rep):
-            return (rep_turnout - 0.1379) + 0.50
-
-   
-        
-    else:
-        def clinton_win(candidates_dem):
-            return (0.1647 - dem_turnout) + 0.50


### PR DESCRIPTION
Left Republican voter turnout and percentages while taking out the section where a Republican winner would be picked. The reasoning behind this is that it was too difficult for me to create code to pick a Rep winner using the same logic I did with the Dems. There were too many Rep candidates.
